### PR TITLE
✨ feat: added new atribute for OrderItem & update code for OrderService & Controller

### DIFF
--- a/src/main/java/br/fatec/easycoast/dtos/orderItem/OrderItemRequest.java
+++ b/src/main/java/br/fatec/easycoast/dtos/orderItem/OrderItemRequest.java
@@ -15,7 +15,8 @@ public record OrderItemRequest(
         Product product,
         List<Addon> addons,
         @NotNull(message = "Order Item order can't be null")
-        Order order
+        Order order,
+        Boolean reversed
 ) {
 
 }

--- a/src/main/java/br/fatec/easycoast/dtos/orderItem/OrderItemResponse.java
+++ b/src/main/java/br/fatec/easycoast/dtos/orderItem/OrderItemResponse.java
@@ -15,6 +15,7 @@ public record OrderItemResponse(
         Integer quantity,
         String observations,
         Double total,
+        Boolean reversed,
         @JsonIgnoreProperties("addonCategories") ProductResponse product,
         List<AddonResponse> addons
 // O campo 'Order order' foi REMOVIDO daqui

--- a/src/main/java/br/fatec/easycoast/dtos/orderItem/OrderItemResponseWithOrder.java
+++ b/src/main/java/br/fatec/easycoast/dtos/orderItem/OrderItemResponseWithOrder.java
@@ -15,6 +15,7 @@ public record OrderItemResponseWithOrder(
         Integer quantity,
         String observations,
         Double total,
+        Boolean reversed,
         @JsonIgnoreProperties("addonCategories") ProductResponse product,
         List<AddonResponse> addons,
         @JsonIgnoreProperties("orderItems") OrderResponse order

--- a/src/main/java/br/fatec/easycoast/entities/OrderItem.java
+++ b/src/main/java/br/fatec/easycoast/entities/OrderItem.java
@@ -27,6 +27,7 @@ public class OrderItem {
 
     private Double total;
 
+    private Boolean reversed = false; 
     @ManyToOne
     @JoinColumn(name = "PRODUCT_ID")
     private Product product;
@@ -39,7 +40,6 @@ public class OrderItem {
     @JsonBackReference
     private Order order;
 
-    // Getters e Setters
     public Integer getId() {
         return id;
     }
@@ -96,4 +96,11 @@ public class OrderItem {
         this.order = order;
     }
 
+    public Boolean getReversed() {
+        return reversed;
+    }
+
+    public void setReversed(Boolean reversed) {
+        this.reversed = reversed;
+    }
 }

--- a/src/main/java/br/fatec/easycoast/mappers/OrderItemMapper.java
+++ b/src/main/java/br/fatec/easycoast/mappers/OrderItemMapper.java
@@ -25,6 +25,7 @@ public class OrderItemMapper {
                 orderItem.getQuantity(),
                 orderItem.getObservations(),
                 orderItem.getTotal(),
+                orderItem.getReversed(), 
                 orderItem.getProduct() != null ? ProductMapper.toDTO(orderItem.getProduct()) : null,
                 orderItem.getAddons() != null ? AddonMapper.toListDTO(orderItem.getAddons(), isPost) : null
         );
@@ -40,6 +41,7 @@ public class OrderItemMapper {
                 orderItem.getQuantity(),
                 orderItem.getObservations(),
                 orderItem.getTotal(),
+                orderItem.getReversed(), 
                 orderItem.getProduct() != null ? ProductMapper.toDTO(orderItem.getProduct()) : null,
                 orderItem.getAddons() != null ? AddonMapper.toListDTO(orderItem.getAddons(), false) : null,
                 orderItem.getOrder() != null ? OrderMapper.toDTO(orderItem.getOrder()) : null

--- a/src/main/java/br/fatec/easycoast/mappers/OrderItemMapper.java
+++ b/src/main/java/br/fatec/easycoast/mappers/OrderItemMapper.java
@@ -16,6 +16,9 @@ public class OrderItemMapper {
         orderItem.setProduct(request.product());
         orderItem.setAddons(request.addons());
         orderItem.setOrder(request.order());
+        if (request.reversed() != null) {
+            orderItem.setReversed(request.reversed());
+        }
         return orderItem;
     }
 
@@ -25,7 +28,7 @@ public class OrderItemMapper {
                 orderItem.getQuantity(),
                 orderItem.getObservations(),
                 orderItem.getTotal(),
-                orderItem.getReversed(), 
+                orderItem.getReversed(),
                 orderItem.getProduct() != null ? ProductMapper.toDTO(orderItem.getProduct()) : null,
                 orderItem.getAddons() != null ? AddonMapper.toListDTO(orderItem.getAddons(), isPost) : null
         );
@@ -34,14 +37,14 @@ public class OrderItemMapper {
     public static OrderItemResponse toDTO(OrderItem orderItem) {
         return toDTO(orderItem, null);
     }
-    
+
     public static OrderItemResponseWithOrder toDTOWithOrder(OrderItem orderItem) {
         return new OrderItemResponseWithOrder(
                 orderItem.getId(),
                 orderItem.getQuantity(),
                 orderItem.getObservations(),
                 orderItem.getTotal(),
-                orderItem.getReversed(), 
+                orderItem.getReversed(),
                 orderItem.getProduct() != null ? ProductMapper.toDTO(orderItem.getProduct()) : null,
                 orderItem.getAddons() != null ? AddonMapper.toListDTO(orderItem.getAddons(), false) : null,
                 orderItem.getOrder() != null ? OrderMapper.toDTO(orderItem.getOrder()) : null
@@ -57,7 +60,7 @@ public class OrderItemMapper {
         }
         return Collections.emptyList();
     }
-    
+
     public static List<OrderItemResponseWithOrder> toListDTOWithOrder(List<OrderItem> orderItems) {
         if (orderItems != null) {
             return orderItems

--- a/src/main/java/br/fatec/easycoast/resources/OrderController.java
+++ b/src/main/java/br/fatec/easycoast/resources/OrderController.java
@@ -61,6 +61,12 @@ public class OrderController {
         orderService.closeOrder(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("{id}/close-without-payment")
+    public ResponseEntity<Void> closeOrderWithoutPayment(@PathVariable int id) {
+        orderService.closeOrderWithoutPayment(id);
+        return ResponseEntity.noContent().build();
+    }
     
     @GetMapping("/by-card/{cardId}")
     public ResponseEntity<OrderResponse> getOrderByCardId(@PathVariable Integer cardId) {

--- a/src/main/java/br/fatec/easycoast/resources/OrderController.java
+++ b/src/main/java/br/fatec/easycoast/resources/OrderController.java
@@ -62,11 +62,7 @@ public class OrderController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("{id}/close-without-payment")
-    public ResponseEntity<Void> closeOrderWithoutPayment(@PathVariable int id) {
-        orderService.closeOrderWithoutPayment(id);
-        return ResponseEntity.noContent().build();
-    }
+     
     
     @GetMapping("/by-card/{cardId}")
     public ResponseEntity<OrderResponse> getOrderByCardId(@PathVariable Integer cardId) {

--- a/src/main/java/br/fatec/easycoast/services/OrderItemService.java
+++ b/src/main/java/br/fatec/easycoast/services/OrderItemService.java
@@ -51,7 +51,7 @@ public class OrderItemService {
                 throw new EntityNotFoundException("Addon incorrect!");
             }
         }
-        
+
         OrderItem orderItem = OrderItemMapper.toEntity(request);
         orderItem.setTotal(calculateOrderItemTotal(orderItem));
         return OrderItemMapper.toDTO(orderItemRepository.save(orderItem), true);
@@ -73,28 +73,27 @@ public class OrderItemService {
             orderItem.setProduct(request.product());
             orderItem.setAddons(request.addons());
             orderItem.setOrder(request.order());
-            // A linha abaixo foi removida para impedir a alteração do estorno por este endpoint
-            // orderItem.setReversed(request.reversed()); 
+            orderItem.setReversed(request.reversed());
             orderItem.setTotal(calculateOrderItemTotal(orderItem));
             orderItemRepository.save(orderItem);
         } catch (EntityNotFoundException e) {
             throw new EntityNotFoundException("Not found Order Item!");
         }
     }
-    
+
     public double calculateOrderItemTotal(OrderItem orderItem) {
         double total = 0.0;
         if (orderItem.getProduct() != null && orderItem.getQuantity() != null) {
             ProductResponse product = productService.getProductById(orderItem.getProduct().getId());
             double productPrice = product.price() - (product.price() * product.discount() / 100);
-            
+
             double addonsPrice = 0.0;
             if (orderItem.getAddons() != null) {
                 addonsPrice = orderItem.getAddons().stream()
                         .mapToDouble(addon -> addonService.getAddonById(addon.getId()).price())
                         .sum();
             }
-            
+
             total = (productPrice + addonsPrice) * orderItem.getQuantity();
         }
         return new BigDecimal(total).setScale(2, RoundingMode.HALF_UP).doubleValue();

--- a/src/main/java/br/fatec/easycoast/services/OrderItemService.java
+++ b/src/main/java/br/fatec/easycoast/services/OrderItemService.java
@@ -16,6 +16,7 @@ import br.fatec.easycoast.entities.OrderItem;
 import br.fatec.easycoast.mappers.OrderItemMapper;
 import br.fatec.easycoast.repositories.AddonRepository;
 import br.fatec.easycoast.repositories.OrderItemRepository;
+import br.fatec.easycoast.repositories.OrderRepository;
 import jakarta.persistence.EntityNotFoundException;
 
 @Service
@@ -26,6 +27,9 @@ public class OrderItemService {
 
     @Autowired
     private AddonRepository addonRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
 
     @Autowired
     private AddonService addonService;
@@ -44,6 +48,9 @@ public class OrderItemService {
     }
 
     public OrderItemResponse saveOrderItem(OrderItemRequest request) {
+        orderRepository.findById(request.order().getId())
+                .orElseThrow(() -> new EntityNotFoundException("Order not found with id: " + request.order().getId()));
+
         List<Integer> addonIds = request.addons().stream().map(Addon::getId).collect(Collectors.toList());
         if (!addonIds.isEmpty()) {
             int addonNumber = addonRepository.findAddonIfexists(addonIds, request.product().getId());
@@ -58,6 +65,9 @@ public class OrderItemService {
     }
 
     public void updateOrderItem(Integer id, OrderItemRequest request) {
+        orderRepository.findById(request.order().getId())
+                .orElseThrow(() -> new EntityNotFoundException("Order not found with id: " + request.order().getId()));
+        
         List<Integer> addonIds = request.addons().stream().map(Addon::getId).collect(Collectors.toList());
         if (!addonIds.isEmpty()) {
             int addonNumber = addonRepository.findAddonIfexists(addonIds, request.product().getId());

--- a/src/main/java/br/fatec/easycoast/services/OrderItemService.java
+++ b/src/main/java/br/fatec/easycoast/services/OrderItemService.java
@@ -73,6 +73,8 @@ public class OrderItemService {
             orderItem.setProduct(request.product());
             orderItem.setAddons(request.addons());
             orderItem.setOrder(request.order());
+            // A linha abaixo foi removida para impedir a alteração do estorno por este endpoint
+            // orderItem.setReversed(request.reversed()); 
             orderItem.setTotal(calculateOrderItemTotal(orderItem));
             orderItemRepository.save(orderItem);
         } catch (EntityNotFoundException e) {

--- a/src/main/java/br/fatec/easycoast/services/OrderService.java
+++ b/src/main/java/br/fatec/easycoast/services/OrderService.java
@@ -201,23 +201,7 @@ public class OrderService {
         orderRepository.save(order);
     }
     
-    @Transactional
-    public void closeOrderWithoutPayment(Integer id) {
-        Order order = orderRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("Order not found by ID: " + id));
-        if (order.getClosingTime() != null) {
-            throw new IllegalStateException("Order is already closed.");
-        }
-        order.setClosingTime(Instant.now());
-
-        Card card = order.getCard();
-        if (card != null) {
-            card.setOrder(null);
-            cardRepository.save(card);
-        }
-
-        orderRepository.save(order);
-    }
-
+    
 
     @Transactional
     public void deactivateCard(Integer cardId) {

--- a/src/main/java/br/fatec/easycoast/services/OrderService.java
+++ b/src/main/java/br/fatec/easycoast/services/OrderService.java
@@ -22,9 +22,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -92,30 +97,50 @@ public class OrderService {
         Order order = orderRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Order not found by ID: " + id));
 
+        if (order.getClosingTime() != null) {
+            throw new IllegalStateException("Order is closed and cannot be modified.");
+        }
+
         if (order.getCard() != null && !order.getCard().getActive()) {
             throw new IllegalStateException("Associated card is inactive/blocked. Order cannot be updated.");
         }
-
-        order.getOrderItems().clear();
-
+    
+        Map<Integer, OrderItem> existingItemsMap = order.getOrderItems().stream()
+                .collect(Collectors.toMap(OrderItem::getId, Function.identity()));
+    
         if (request.orderItems() != null) {
             for (OrderItem requestedItem : request.orderItems()) {
-                Product productEntity = productRepository.findById(requestedItem.getProduct().getId())
-                        .orElseThrow(() -> new EntityNotFoundException("Product not found"));
-
-                OrderItem newItem = new OrderItem();
-                newItem.setOrder(order);
-                newItem.setProduct(productEntity);
-                newItem.setQuantity(requestedItem.getQuantity());
-                newItem.setObservations(requestedItem.getObservations());
-                newItem.setAddons(requestedItem.getAddons());
-                newItem.setReversed(requestedItem.getReversed());
-                newItem.setTotal(orderItemService.calculateOrderItemTotal(newItem));
-                
-                order.getOrderItems().add(newItem);
+                if (requestedItem.getId() != null && existingItemsMap.containsKey(requestedItem.getId())) {
+                    OrderItem existingItem = existingItemsMap.get(requestedItem.getId());
+                    existingItem.setQuantity(requestedItem.getQuantity());
+                    existingItem.setObservations(requestedItem.getObservations());
+                    existingItem.setAddons(requestedItem.getAddons());
+                    existingItem.setReversed(requestedItem.getReversed()); 
+                    existingItem.setTotal(orderItemService.calculateOrderItemTotal(existingItem));
+                } else { 
+                    Product productEntity = productRepository.findById(requestedItem.getProduct().getId())
+                            .orElseThrow(() -> new EntityNotFoundException("Product not found"));
+    
+                    OrderItem newItem = new OrderItem();
+                    newItem.setOrder(order);
+                    newItem.setProduct(productEntity);
+                    newItem.setQuantity(requestedItem.getQuantity());
+                    newItem.setObservations(requestedItem.getObservations());
+                    newItem.setAddons(requestedItem.getAddons());
+                    newItem.setReversed(requestedItem.getReversed());
+                    newItem.setTotal(orderItemService.calculateOrderItemTotal(newItem));
+                    order.getOrderItems().add(newItem);
+                }
             }
         }
         
+        List<Integer> requestItemIds = request.orderItems() != null ? 
+            request.orderItems().stream()
+            .map(OrderItem::getId)
+            .collect(Collectors.toList()) : Collections.emptyList();
+    
+        order.getOrderItems().removeIf(item -> item.getId() != null && !requestItemIds.contains(item.getId()));
+
         Order savedOrder = orderRepository.save(order);
         updateTotal(savedOrder.getId());
         
@@ -161,11 +186,16 @@ public class OrderService {
             throw new IllegalStateException("Este pedido já está fechado.");
         }
         
-        double orderTotal = orderWithTotal.getTotal() != null ? orderWithTotal.getTotal() : 0.0;
-        double orderTotalWithTip = orderTotal * 1.1; 
-        double totalPaid = request.payments().stream().mapToDouble(PaymentPart::amount).sum();
-        
-        if (Math.abs(totalPaid - orderTotalWithTip) > 0.01) {
+        double orderTotalDouble = orderWithTotal.getTotal() != null ? orderWithTotal.getTotal() : 0.0;
+        double totalPaidDouble = request.payments().stream().mapToDouble(PaymentPart::amount).sum();
+
+        BigDecimal orderTotal = BigDecimal.valueOf(orderTotalDouble).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal totalPaid = BigDecimal.valueOf(totalPaidDouble).setScale(2, RoundingMode.HALF_UP);
+
+        BigDecimal tipMultiplier = new BigDecimal("1.1");
+        BigDecimal orderTotalWithTip = orderTotal.multiply(tipMultiplier).setScale(2, RoundingMode.HALF_UP);
+
+        if (totalPaid.compareTo(orderTotalWithTip) != 0) {
             throw new IllegalStateException(
                 String.format("O valor pago (R$%.2f) não corresponde ao total do pedido com gorjeta (R$%.2f).", totalPaid, orderTotalWithTip)
             );

--- a/src/main/java/br/fatec/easycoast/services/OrderService.java
+++ b/src/main/java/br/fatec/easycoast/services/OrderService.java
@@ -109,6 +109,7 @@ public class OrderService {
                 newItem.setQuantity(requestedItem.getQuantity());
                 newItem.setObservations(requestedItem.getObservations());
                 newItem.setAddons(requestedItem.getAddons());
+                newItem.setReversed(requestedItem.getReversed());
                 newItem.setTotal(orderItemService.calculateOrderItemTotal(newItem));
                 
                 order.getOrderItems().add(newItem);
@@ -127,6 +128,7 @@ public class OrderService {
                 .orElseThrow(() -> new EntityNotFoundException("Order not found to update total: " + id));
         
         double newTotal = order.getOrderItems().stream()
+                .filter(item -> !Boolean.TRUE.equals(item.getReversed()))
                 .mapToDouble(OrderItem::getTotal)
                 .sum();
         
@@ -138,6 +140,14 @@ public class OrderService {
     public void processPayment(Integer orderId, ProcessPaymentRequest request) {
         Order updatedOrder = orderRepository.findById(orderId)
                 .orElseThrow(() -> new EntityNotFoundException("Order not found: " + orderId));
+
+        long activeItemsCount = updatedOrder.getOrderItems().stream()
+                .filter(item -> !Boolean.TRUE.equals(item.getReversed()))
+                .count();
+
+        if (activeItemsCount == 0) {
+            throw new IllegalStateException("Cannot process payment for an order with no active items.");
+        }
 
         if (updatedOrder.getCard() != null && !updatedOrder.getCard().getActive()) {
             throw new IllegalStateException("Associated card is inactive/blocked. Payment not allowed.");
@@ -190,6 +200,24 @@ public class OrderService {
         
         orderRepository.save(order);
     }
+    
+    @Transactional
+    public void closeOrderWithoutPayment(Integer id) {
+        Order order = orderRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("Order not found by ID: " + id));
+        if (order.getClosingTime() != null) {
+            throw new IllegalStateException("Order is already closed.");
+        }
+        order.setClosingTime(Instant.now());
+
+        Card card = order.getCard();
+        if (card != null) {
+            card.setOrder(null);
+            cardRepository.save(card);
+        }
+
+        orderRepository.save(order);
+    }
+
 
     @Transactional
     public void deactivateCard(Integer cardId) {


### PR DESCRIPTION
Close #128 

To test it, run that command:
`mvnw spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=dev --dbPort=5432 --dbName=EasyCoast --dbUser=postgres --dbPwd=123"`


On API, use those scripts: 

For OrderItem's reversed atribute:
- POST `http://localhost:8080/orders`
JSON

```{
    "openingTime": "2025-09-25T22:30:00.000Z",
    "card": {
        "id": 4
    },
    "orderItems": [
        {
            "quantity": 1,
            "product": { "id": 1 }
        },
        {
            "quantity": 2,
            "product": { "id": 2 }
        }
    ]
}
```

- PUT `http://localhost:8080/orders/10` (replace 10 with the real order ID)
JSON

```{
    "card": { "id": 4 },
    "orderItems": [
        {
            "quantity": 1,
            "product": { "id": 1 },
            "reversed": false
        },
        {
            "quantity": 2,
            "product": { "id": 2 },
            "reversed": true
        }
    ]
}
```


For Close Order without Payment:
If you do not have an open request to test, you can create one with the request I
sent earlier. `(POST /orders)`.

If you already have orders created, you can list them all with a GET and get the ID of one that does not yet have a closingTime (i.e., one that is still open).

- GET `http://localhost:8080/orders`

- PUT `http://localhost:8080/orders/10/close-without-payment` (remember to replace 10 with the ID of the order you want to close).